### PR TITLE
chore: improve first-time setup experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Zero Code Instrumentation with eBPF
 
+## Prerequisites
+
+- Java
+- Maven
+
+## Setup
+
 The following script will create a kind cluster and deploy the demo there.
 
 ```

--- a/demo-services/frontend/build.sh
+++ b/demo-services/frontend/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -e
+
 docker build -t beyla-demo/frontend .

--- a/demo-services/greeting-service/build.sh
+++ b/demo-services/greeting-service/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -e
+
 docker build -t beyla-demo/greeting-service .

--- a/demo-services/planet-service/build.sh
+++ b/demo-services/planet-service/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+set -e
+
+mvn wrapper:wrapper
 ./mvnw clean package
 docker build -t beyla-demo/planet-service .


### PR DESCRIPTION
`mvnw` does not exist on a freshly cloned repo, and the service build scripts were skipping over the error.