### PR TITLE
grafana: disable login form, auth and allow anon usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Now, run the following command to expose port 3000 of the Grafana Pod on localho
 kubectl port-forward $(kubectl get pods -lapp=grafana -o=name) 3000:3000
 ```
 
-Access Grafana on http://localhost:3000. Default username is _admin_ with password _admin_.
+Access Grafana on http://localhost:3000, Auth and login is disabled because this is demo deployment, and default user role is Admin.
 
 Click on Dashboards (menu on the left) -> RED metrics (list of dashboards) to view an example RED metrics dashboard.
 

--- a/deploy/grafana.yaml
+++ b/deploy/grafana.yaml
@@ -20,6 +20,13 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
+        env:
+        - name: GF_AUTH_ANONYMOUS_ENABLED
+          value: "true"
+        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+          value: "Admin"
+        - name: GF_AUTH_DISABLE_LOGIN_FORM
+          value: "true"
         volumeMounts:
         - mountPath: /etc/grafana/provisioning
           name: grafana-provisioning


### PR DESCRIPTION
disabled the login to skip the login into the demo setup.